### PR TITLE
Describe "via" model in many2many fields.

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3291,6 +3291,10 @@ class Many2many(_RelationalMulti):
             **kwargs
         )
 
+    _description_via_relation = property(attrgetter('relation'))
+    _description_via_these = property(attrgetter('column1'))
+    _description_via_those = property(attrgetter('column2'))
+
     def _setup_regular_base(self, model):
         super(Many2many, self)._setup_regular_base(model)
         # 3 cases:


### PR DESCRIPTION
It is sometimes impossible to determine which table is used for the actual references in many2many relationships, because while some use the canonical `these_those_rel` naming scheme, not all do, and even the ones that do don't specify the order of `these` and `those`.  This just adds 3 more `_description_`s to the `Many2many` class - `via_relation`, `via_these`, and `via_those` so that the `get_fields` API call can know all about how those relationships work.

* `via_these` will return the name of the field in the `via` model that is the foreign key to the current model.
* `via_those` is the foreign key for the counterpart model (`comodel`, as returned by `relation`).

These two fields are correctly reversed when called on the comodel.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
